### PR TITLE
Splash Page - Remove variable banner.title

### DIFF
--- a/cookiecutter.yaml
+++ b/cookiecutter.yaml
@@ -25,7 +25,6 @@ hackweek_mission: https://escience.washington.edu/using-data-science/hackweeks
 #redirect:
 #    url: https://icesat-2-2023.hackweek.io
 banner:
-  title: IceSat-2 Hackweek
   description: An in person, collaborative learning event.
   start_date: Late
   end_date: Summer

--- a/{{ cookiecutter.repo_directory }}/index.html
+++ b/{{ cookiecutter.repo_directory }}/index.html
@@ -102,7 +102,7 @@
     <div class="container">
         <div class="hero-text-block">
             <h1 class="hero-heading mb-2">
-                {{ cookiecutter.banner.title }} {{ cookiecutter.banner.year }}
+                {{ cookiecutter.name }} {{ cookiecutter.banner.year }}
             </h1>
             <div class="hero-meta mb-3">
                 <i class="far fa-calendar-alt me-2"></i>


### PR DESCRIPTION
The banner title can be replaced with the main 'name' variable.